### PR TITLE
new/elegen: complain when a bson name is reused

### DIFF
--- a/cmd/elegen/writers.go
+++ b/cmd/elegen/writers.go
@@ -57,6 +57,19 @@ func writeModel(set spec.SpecificationSet, name string, outFolder string, public
 
 	s := set.Specification(name)
 
+	bnames := map[string]struct{}{}
+	for _, attr := range s.Attributes(s.LatestAttributesVersion()) {
+		item, ok := attr.Extensions["bson_name"]
+		if !ok {
+			continue
+		}
+		bname := item.(string)
+		if _, ok = bnames[bname]; ok {
+			return fmt.Errorf("invalid bson name. '%s' reused", bname)
+		}
+		bnames[bname] = struct{}{}
+	}
+
 	if s.Model().Private && publicMode {
 		return nil
 	}


### PR DESCRIPTION
This patch adds a validation to ensure unicity of bson_name is a spec.