### PR TITLE
fixed: fix panic on nil input in ResetSecretAttributesValues

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -208,6 +208,15 @@ type AttributeSpecification struct {
 // If you pass anything else, this function does nothing.
 func ResetSecretAttributesValues(obj interface{}) {
 
+	if obj == nil {
+		return
+	}
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return
+	}
+
 	strip := func(o Identifiable) {
 
 		oo := o

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -164,13 +164,33 @@ func Test_ResetSecretAttributesValues(t *testing.T) {
 
 		s := &struct{}{}
 
-		Convey("When I call ResetSecretAttributesValues", func() {
+		Convey("Then it should not panic", func() {
+			So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
+		})
+	})
 
-			ResetSecretAttributesValues(s)
+	Convey("Given I have some nil pointer struct", t, func() {
 
-			Convey("Then it should not panic", func() {
-				So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
-			})
+		var s *struct{}
+
+		Convey("Then it should not panic", func() {
+			So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
+		})
+	})
+
+	Convey("Given I have some nil value", t, func() {
+
+		Convey("Then it should not panic", func() {
+			So(func() { ResetSecretAttributesValues(nil) }, ShouldNotPanic)
+		})
+	})
+
+	Convey("Given I have some nil pointer identifiable", t, func() {
+
+		var s *List
+
+		Convey("Then it should not panic", func() {
+			So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
 		})
 	})
 


### PR DESCRIPTION
this patch fixes a panic when various nil values were passed to ResetSecretAttributesValues.