### PR TITLE
Enahncement/openapi3: include tags + operationID

### DIFF
--- a/cmd/internal/genopenapi3/converter_relations_model_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_model_nonroot_test.go
@@ -13,8 +13,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Resource
-					package: None
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: useful description.
 					get:
 						description: Retrieves the resource with the given ID.
@@ -50,6 +50,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							],
 							"get": {
 								"operationId": "get-resource-by-ID",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Retrieves the resource with the given ID.",
 								"parameters": [
 									{
@@ -87,8 +88,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Resource
-					package: None
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: useful description.
 					delete:
 						description: Deletes the resource with the given ID.
@@ -121,6 +122,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							],
 							"delete": {
 								"operationId": "delete-resource-by-ID",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Deletes the resource with the given ID.",
 								"parameters": [
 									{
@@ -157,8 +159,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Resource
-					package: None
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: useful description.
 					update:
 						description: Updates the resource with the given ID.
@@ -194,6 +196,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							],
 							"put": {
 								"operationId": "update-resource-by-ID",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Updates the resource with the given ID.",
 								"parameters": [
 									{
@@ -239,8 +242,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Resource
-					package: None
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: useful description.
 					get:
 						description: Retrieves the resource with the given ID.
@@ -272,6 +275,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							],
 							"get": {
 								"operationId": "get-resource-by-ID",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Retrieves the resource with the given ID.",
 								"responses": {
 									"200": {
@@ -288,6 +292,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							},
 							"delete": {
 								"operationId": "delete-resource-by-ID",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Deletes the resource with the given ID.",
 								"responses": {
 									"200": {
@@ -304,6 +309,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							},
 							"put": {
 								"operationId": "update-resource-by-ID",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Updates the resource with the given ID.",
 								"requestBody": {
 									"content": {

--- a/cmd/internal/genopenapi3/converter_relations_model_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_model_nonroot_test.go
@@ -49,6 +49,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"get": {
+								"operationId": "get-resource-by-ID",
 								"description": "Retrieves the resource with the given ID.",
 								"parameters": [
 									{
@@ -119,6 +120,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"delete": {
+								"operationId": "delete-resource-by-ID",
 								"description": "Deletes the resource with the given ID.",
 								"parameters": [
 									{
@@ -191,6 +193,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"put": {
+								"operationId": "update-resource-by-ID",
 								"description": "Updates the resource with the given ID.",
 								"parameters": [
 									{
@@ -268,6 +271,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"get": {
+								"operationId": "get-resource-by-ID",
 								"description": "Retrieves the resource with the given ID.",
 								"responses": {
 									"200": {
@@ -283,6 +287,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								}
 							},
 							"delete": {
+								"operationId": "delete-resource-by-ID",
 								"description": "Deletes the resource with the given ID.",
 								"responses": {
 									"200": {
@@ -298,6 +303,7 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								}
 							},
 							"put": {
+								"operationId": "update-resource-by-ID",
 								"description": "Updates the resource with the given ID.",
 								"requestBody": {
 									"content": {

--- a/cmd/internal/genopenapi3/converter_relations_spec_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_spec_nonroot_test.go
@@ -56,6 +56,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"get": {
+								"operationId": "get-all-minesites-for-a-given-resource",
 								"description": "Retrieve all mine sites.",
 								"parameters": [
 									{
@@ -155,6 +156,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"post": {
+								"operationId": "create-a-new-minesite-for-a-given-resource",
 								"description": "Creates a mine site.",
 								"parameters": [
 									{
@@ -284,6 +286,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 								}
 							],
 							"post": {
+								"operationId": "create-a-new-minesite-for-a-given-resource",
 								"description": "Creates a mine site.",
 								"requestBody": {
 									"content": {
@@ -308,6 +311,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 								}
 							},
 							"get": {
+								"operationId": "get-all-minesites-for-a-given-resource",
 								"description": "Retrieve all mine sites.",
 								"responses": {
 									"200": {

--- a/cmd/internal/genopenapi3/converter_relations_spec_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_spec_nonroot_test.go
@@ -57,6 +57,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							],
 							"get": {
 								"operationId": "get-all-minesites-for-a-given-resource",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Retrieve all mine sites.",
 								"parameters": [
 									{
@@ -103,8 +104,8 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 					rest_name: minesite
 					resource_name: minesites
 					entity_name: MineSites
-					package: none
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: Represents a resource mine site.
 			`},
 		},
@@ -157,6 +158,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							],
 							"post": {
 								"operationId": "create-a-new-minesite-for-a-given-resource",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Creates a mine site.",
 								"parameters": [
 									{
@@ -199,8 +201,8 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 					rest_name: minesite
 					resource_name: minesites
 					entity_name: MineSites
-					package: none
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: Represents a resource mine site.
 			`},
 		},
@@ -287,6 +289,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							],
 							"post": {
 								"operationId": "create-a-new-minesite-for-a-given-resource",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Creates a mine site.",
 								"requestBody": {
 									"content": {
@@ -312,6 +315,7 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							},
 							"get": {
 								"operationId": "get-all-minesites-for-a-given-resource",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Retrieve all mine sites.",
 								"responses": {
 									"200": {
@@ -338,8 +342,8 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 					rest_name: minesite
 					resource_name: minesites
 					entity_name: MineSites
-					package: none
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: Represents a resource mine site.
 			`},
 		},

--- a/cmd/internal/genopenapi3/converter_relations_spec_root_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_spec_root_test.go
@@ -42,6 +42,7 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 					"paths": {
 						"/resources": {
 							"post": {
+								"operationId": "create-a-new-resource",
 								"parameters": [
 									{
 										"description": "This is a fancy parameter.",
@@ -123,6 +124,7 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 					"paths": {
 						"/resources": {
 							"get": {
+								"operationId": "get-all-resources",
 								"description": "Retrieve all resources.",
 								"parameters": [
 								  {

--- a/cmd/internal/genopenapi3/converter_relations_spec_root_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_spec_root_test.go
@@ -43,6 +43,7 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 						"/resources": {
 							"post": {
 								"operationId": "create-a-new-resource",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"parameters": [
 									{
 										"description": "This is a fancy parameter.",
@@ -85,8 +86,8 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Recource
-					package: none
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: Represents a resource.
 			`},
 		},
@@ -125,6 +126,7 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 						"/resources": {
 							"get": {
 								"operationId": "get-all-resources",
+								"tags": ["useful/thing", "usefulPackageName"],
 								"description": "Retrieve all resources.",
 								"parameters": [
 								  {
@@ -161,8 +163,8 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Recource
-					package: none
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: Represents a resource.
 			`},
 		},
@@ -198,8 +200,8 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 					rest_name: resource
 					resource_name: resources
 					entity_name: Recource
-					package: none
-					group: N/A
+					package: usefulPackageName
+					group: useful/thing
 					description: Represents a resource.
 			`},
 		},

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -48,7 +48,8 @@ func newConverter(inSpecSet spec.SpecificationSet, skipPrivateModels bool) *conv
 	}
 
 	for _, spec := range inSpecSet.Specifications() {
-		c.resourceToRest[spec.Model().ResourceName] = spec.Model().RestName
+		model := spec.Model()
+		c.resourceToRest[model.ResourceName] = model.RestName
 	}
 
 	return c

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -14,6 +14,7 @@ const paramNameID = "id"
 type converter struct {
 	skipPrivateModels bool
 	inSpecSet         spec.SpecificationSet
+	resourceToRest    map[string]string
 	outRootDoc        openapi3.T
 }
 
@@ -22,6 +23,7 @@ func newConverter(inSpecSet spec.SpecificationSet, skipPrivateModels bool) *conv
 	c := &converter{
 		skipPrivateModels: skipPrivateModels,
 		inSpecSet:         inSpecSet,
+		resourceToRest:    make(map[string]string),
 		outRootDoc: openapi3.T{
 			OpenAPI: "3.0.3",
 			Info: &openapi3.Info{
@@ -44,6 +46,11 @@ func newConverter(inSpecSet spec.SpecificationSet, skipPrivateModels bool) *conv
 			},
 		},
 	}
+
+	for _, spec := range inSpecSet.Specifications() {
+		c.resourceToRest[spec.Model().ResourceName] = spec.Model().RestName
+	}
+
 	return c
 }
 

--- a/cmd/internal/genopenapi3/gen_relations.go
+++ b/cmd/internal/genopenapi3/gen_relations.go
@@ -20,8 +20,8 @@ func (c *converter) convertRelationsForRootSpec(relations []*spec.Relation) map[
 		}
 
 		pathItem := &openapi3.PathItem{
-			Get:  c.extractOperationGetAll(relation, ""),
-			Post: c.extractOperationPost(relation, ""),
+			Get:  c.extractOperationGetAll("", relation),
+			Post: c.extractOperationPost("", relation),
 		}
 
 		model := relation.Specification().Model()
@@ -44,8 +44,8 @@ func (c *converter) convertRelationsForNonRootSpec(parentResourceName string, re
 		}
 
 		pathItem := &openapi3.PathItem{
-			Get:  c.extractOperationGetAll(relation, parentRestName),
-			Post: c.extractOperationPost(relation, parentRestName),
+			Get:  c.extractOperationGetAll(parentRestName, relation),
+			Post: c.extractOperationPost(parentRestName, relation),
 		}
 
 		c.insertParamID(&pathItem.Parameters)
@@ -76,7 +76,7 @@ func (c *converter) convertRelationsForNonRootModel(model *spec.Model) map[strin
 	return pathItems
 }
 
-func (c *converter) extractOperationGetAll(relation *spec.Relation, parentRestName string) *openapi3.Operation {
+func (c *converter) extractOperationGetAll(parentRestName string, relation *spec.Relation) *openapi3.Operation {
 
 	if relation == nil || relation.Get == nil {
 		return nil
@@ -114,7 +114,7 @@ func (c *converter) extractOperationGetAll(relation *spec.Relation, parentRestNa
 	return op
 }
 
-func (c *converter) extractOperationPost(relation *spec.Relation, parentRestName string) *openapi3.Operation {
+func (c *converter) extractOperationPost(parentRestName string, relation *spec.Relation) *openapi3.Operation {
 
 	if relation == nil || relation.Create == nil {
 		return nil

--- a/cmd/internal/genopenapi3/gen_relations.go
+++ b/cmd/internal/genopenapi3/gen_relations.go
@@ -104,33 +104,10 @@ func (c *converter) convertRelationsForNonRootModel(model *spec.Model) map[strin
 		return nil
 	}
 
-	tags := []string{model.Group, model.Package}
-
 	pathItem := &openapi3.PathItem{
-		Get: c.convertRelationActionToGetByID(
-			model.Get,
-			operationConfig{
-				id:     fmt.Sprintf("get-%s-by-ID", model.RestName),
-				tags:   tags,
-				schema: model.RestName,
-			},
-		),
-		Delete: c.convertRelationActionToDeleteByID(
-			model.Delete,
-			operationConfig{
-				id:     fmt.Sprintf("delete-%s-by-ID", model.RestName),
-				tags:   tags,
-				schema: model.RestName,
-			},
-		),
-		Put: c.convertRelationActionToPutByID(
-			model.Update,
-			operationConfig{
-				id:     fmt.Sprintf("update-%s-by-ID", model.RestName),
-				tags:   tags,
-				schema: model.RestName,
-			},
-		),
+		Get:    c.extractOperationGetByID(model),
+		Delete: c.extractOperationDeleteByID(model),
+		Put:    c.extractOperationPutByID(model),
 	}
 	c.insertParamID(&pathItem.Parameters)
 
@@ -211,17 +188,18 @@ func (c *converter) convertRelationActionToPost(relationAction *spec.RelationAct
 	return op
 }
 
-func (c *converter) convertRelationActionToGetByID(relationAction *spec.RelationAction, cfg operationConfig) *openapi3.Operation {
+func (c *converter) extractOperationGetByID(model *spec.Model) *openapi3.Operation {
 
-	if relationAction == nil {
+	if model == nil || model.Get == nil {
 		return nil
 	}
+	relationAction := model.Get
 
-	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
+	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+model.RestName, nil)
 
 	op := &openapi3.Operation{
-		OperationID: cfg.id,
-		Tags:        cfg.tags,
+		OperationID: fmt.Sprintf("get-%s-by-ID", model.RestName),
+		Tags:        []string{model.Group, model.Package},
 		Description: relationAction.Description,
 		Responses: openapi3.Responses{
 			"200": &openapi3.ResponseRef{
@@ -242,17 +220,18 @@ func (c *converter) convertRelationActionToGetByID(relationAction *spec.Relation
 	return op
 }
 
-func (c *converter) convertRelationActionToDeleteByID(relationAction *spec.RelationAction, cfg operationConfig) *openapi3.Operation {
+func (c *converter) extractOperationDeleteByID(model *spec.Model) *openapi3.Operation {
 
-	if relationAction == nil {
+	if model == nil || model.Delete == nil {
 		return nil
 	}
+	relationAction := model.Delete
 
-	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
+	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+model.RestName, nil)
 
 	op := &openapi3.Operation{
-		OperationID: cfg.id,
-		Tags:        cfg.tags,
+		OperationID: fmt.Sprintf("delete-%s-by-ID", model.RestName),
+		Tags:        []string{model.Group, model.Package},
 		Description: relationAction.Description,
 		Responses: openapi3.Responses{
 			"200": &openapi3.ResponseRef{
@@ -273,17 +252,18 @@ func (c *converter) convertRelationActionToDeleteByID(relationAction *spec.Relat
 	return op
 }
 
-func (c *converter) convertRelationActionToPutByID(relationAction *spec.RelationAction, cfg operationConfig) *openapi3.Operation {
+func (c *converter) extractOperationPutByID(model *spec.Model) *openapi3.Operation {
 
-	if relationAction == nil {
+	if model == nil || model.Update == nil {
 		return nil
 	}
+	relationAction := model.Update
 
-	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
+	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+model.RestName, nil)
 
 	op := &openapi3.Operation{
-		OperationID: cfg.id,
-		Tags:        cfg.tags,
+		OperationID: fmt.Sprintf("update-%s-by-ID", model.RestName),
+		Tags:        []string{model.Group, model.Package},
 		Description: relationAction.Description,
 		RequestBody: &openapi3.RequestBodyRef{
 			Value: &openapi3.RequestBody{

--- a/cmd/internal/genopenapi3/gen_relations.go
+++ b/cmd/internal/genopenapi3/gen_relations.go
@@ -32,10 +32,10 @@ func (c *converter) convertRelationsForRootSpec(relations []*spec.Relation) map[
 	return paths
 }
 
-func (c *converter) convertRelationsForNonRootSpec(parentResourceName string, relations []*spec.Relation) map[string]*openapi3.PathItem {
+func (c *converter) convertRelationsForNonRootSpec(resourceName string, relations []*spec.Relation) map[string]*openapi3.PathItem {
 
 	paths := make(map[string]*openapi3.PathItem)
-	parentRestName := c.resourceToRest[parentResourceName]
+	parentRestName := c.resourceToRest[resourceName]
 
 	for _, relation := range relations {
 
@@ -51,7 +51,7 @@ func (c *converter) convertRelationsForNonRootSpec(parentResourceName string, re
 		c.insertParamID(&pathItem.Parameters)
 
 		childModel := c.inSpecSet.Specification(relation.RestName).Model()
-		uri := fmt.Sprintf("/%s/{%s}/%s", parentResourceName, paramNameID, childModel.ResourceName)
+		uri := fmt.Sprintf("/%s/{%s}/%s", resourceName, paramNameID, childModel.ResourceName)
 		paths[uri] = pathItem
 	}
 

--- a/cmd/internal/genopenapi3/gen_relations.go
+++ b/cmd/internal/genopenapi3/gen_relations.go
@@ -10,9 +10,9 @@ import (
 var noDesc = "n/a"
 
 type operationConfig struct {
-	id       string
-	restName string
-	tags     []string
+	id     string
+	schema string
+	tags   []string
 }
 
 func (c *converter) convertRelationsForRootSpec(relations []*spec.Relation) map[string]*openapi3.PathItem {
@@ -32,17 +32,17 @@ func (c *converter) convertRelationsForRootSpec(relations []*spec.Relation) map[
 			Get: c.convertRelationActionToGetAll(
 				relation.Get,
 				operationConfig{
-					id:       "get-all-" + model.ResourceName,
-					restName: relation.RestName,
-					tags:     tags,
+					id:     "get-all-" + model.ResourceName,
+					schema: relation.RestName,
+					tags:   tags,
 				},
 			),
 			Post: c.convertRelationActionToPost(
 				relation.Create,
 				operationConfig{
-					id:       "create-a-new-" + relation.RestName,
-					restName: relation.RestName,
-					tags:     tags,
+					id:     "create-a-new-" + relation.RestName,
+					schema: relation.RestName,
+					tags:   tags,
 				},
 			),
 		}
@@ -74,17 +74,17 @@ func (c *converter) convertRelationsForNonRootSpec(resourceName string, relation
 			Get: c.convertRelationActionToGetAll(
 				relation.Get,
 				operationConfig{
-					id:       "get-all-" + childResourceName + "-for-a-given-" + parentRestName,
-					tags:     tags,
-					restName: childRestName,
+					id:     "get-all-" + childResourceName + "-for-a-given-" + parentRestName,
+					tags:   tags,
+					schema: childRestName,
 				},
 			),
 			Post: c.convertRelationActionToPost(
 				relation.Create,
 				operationConfig{
-					id:       "create-a-new-" + childRestName + "-for-a-given-" + parentRestName,
-					tags:     tags,
-					restName: childRestName,
+					id:     "create-a-new-" + childRestName + "-for-a-given-" + parentRestName,
+					tags:   tags,
+					schema: childRestName,
 				},
 			),
 		}
@@ -110,25 +110,25 @@ func (c *converter) convertRelationsForNonRootModel(model *spec.Model) map[strin
 		Get: c.convertRelationActionToGetByID(
 			model.Get,
 			operationConfig{
-				id:       fmt.Sprintf("get-%s-by-ID", model.RestName),
-				tags:     tags,
-				restName: model.RestName,
+				id:     fmt.Sprintf("get-%s-by-ID", model.RestName),
+				tags:   tags,
+				schema: model.RestName,
 			},
 		),
 		Delete: c.convertRelationActionToDeleteByID(
 			model.Delete,
 			operationConfig{
-				id:       fmt.Sprintf("delete-%s-by-ID", model.RestName),
-				tags:     tags,
-				restName: model.RestName,
+				id:     fmt.Sprintf("delete-%s-by-ID", model.RestName),
+				tags:   tags,
+				schema: model.RestName,
 			},
 		),
 		Put: c.convertRelationActionToPutByID(
 			model.Update,
 			operationConfig{
-				id:       fmt.Sprintf("update-%s-by-ID", model.RestName),
-				tags:     tags,
-				restName: model.RestName,
+				id:     fmt.Sprintf("update-%s-by-ID", model.RestName),
+				tags:   tags,
+				schema: model.RestName,
 			},
 		),
 	}
@@ -146,7 +146,7 @@ func (c *converter) convertRelationActionToGetAll(relationAction *spec.RelationA
 	}
 
 	respBodySchema := openapi3.NewArraySchema()
-	respBodySchema.Items = openapi3.NewSchemaRef("#/components/schemas/"+cfg.restName, nil)
+	respBodySchema.Items = openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
 
 	op := &openapi3.Operation{
 		OperationID: cfg.id,
@@ -177,7 +177,7 @@ func (c *converter) convertRelationActionToPost(relationAction *spec.RelationAct
 		return nil
 	}
 
-	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.restName, nil)
+	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
 
 	op := &openapi3.Operation{
 		OperationID: cfg.id,
@@ -217,7 +217,7 @@ func (c *converter) convertRelationActionToGetByID(relationAction *spec.Relation
 		return nil
 	}
 
-	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.restName, nil)
+	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
 
 	op := &openapi3.Operation{
 		OperationID: cfg.id,
@@ -248,7 +248,7 @@ func (c *converter) convertRelationActionToDeleteByID(relationAction *spec.Relat
 		return nil
 	}
 
-	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.restName, nil)
+	respBodySchemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
 
 	op := &openapi3.Operation{
 		OperationID: cfg.id,
@@ -279,7 +279,7 @@ func (c *converter) convertRelationActionToPutByID(relationAction *spec.Relation
 		return nil
 	}
 
-	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.restName, nil)
+	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+cfg.schema, nil)
 
 	op := &openapi3.Operation{
 		OperationID: cfg.id,


### PR DESCRIPTION
This PR ensures that fields `tags` and `operationId` are populated in the output OpenAPI3 doc:

eg:
```
"/accessiblenamespaces": {
      "get":{
        "operationId": "get-all-accessiblenamespaces",
        "tags": ["core/accessiblenamespace", "squall"],
...
```

This is done for all operations, ie GET/POST/PUT/DELETE