### PR TITLE
Enhancement/openapi3: support writing doc in multiple files

### DIFF
--- a/cmd/elegen/main.go
+++ b/cmd/elegen/main.go
@@ -36,14 +36,20 @@ func main() {
 
 	// will be initialized later
 	var (
-		genType    string
-		publicMode bool
+		genType     string
+		publicMode  bool
+		splitOutput bool
 	)
 
 	generator := func(sets []spec.SpecificationSet, out string) error {
 		switch genType {
 		case "openapi3":
-			return genopenapi3.GeneratorFunc(sets, out, publicMode)
+			cfg := genopenapi3.Config{
+				Public:      publicMode,
+				SplitOutput: splitOutput,
+				OutputDir:   out,
+			}
+			return genopenapi3.GeneratorFunc(sets, cfg)
 		case "", "elemental":
 			return genElemental(sets, out, publicMode)
 		default:
@@ -67,6 +73,12 @@ func main() {
 		"public",
 		false,
 		"If set to true, only exposed attributes and public objects will be generated",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&splitOutput,
+		"split-output",
+		false,
+		"If set to true, the openapi3 output will be split into multiple files",
 	)
 	cmd.PersistentFlags().StringVarP(
 		&genType,

--- a/cmd/internal/genopenapi3/converter_errors_test.go
+++ b/cmd/internal/genopenapi3/converter_errors_test.go
@@ -2,6 +2,7 @@ package genopenapi3
 
 import (
 	"errors"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -64,7 +65,7 @@ func TestConverter_Do__error_bad_externalType_mapping(t *testing.T) {
 		t.Fatalf("error parsing spec set from test data: %v", err)
 	}
 
-	converter := newConverter(spec, false)
+	converter := newConverter(spec, Config{})
 	if err := converter.Do(nil); !errors.Is(err, errUnmarshalingExternalType) {
 		t.Fatalf("unexpected error\nwant: %v\n got: %v", errUnmarshalingExternalType, err)
 	}

--- a/cmd/internal/genopenapi3/converter_errors_test.go
+++ b/cmd/internal/genopenapi3/converter_errors_test.go
@@ -71,7 +71,7 @@ func TestConverter_Do__error_bad_externalType_mapping(t *testing.T) {
 	}
 }
 
-func TestConverter_Do__error_bad_write_destination(t *testing.T) {
+func TestConverter_Do__error_writer(t *testing.T) {
 
 	specDir, err := ioutil.TempDir("", t.Name()+"_*")
 	if err != nil {
@@ -111,11 +111,18 @@ func TestConverter_Do__error_bad_write_destination(t *testing.T) {
 		t.Fatalf("error parsing spec set from test data: %v", err)
 	}
 
-	simulatedErr := errors.New("simulated error")
-	fw := &fakeWriter{err: simulatedErr}
+	simulatedErr1 := errors.New("simulated error 1")
+	fw := &fakeWriter{wrErr: simulatedErr1}
+	writerFactory := func(string) (io.WriteCloser, error) { return fw, nil }
+	converter := newConverter(spec, Config{})
+	if err := converter.Do(writerFactory); !errors.Is(err, simulatedErr1) {
+		t.Fatalf("unexpected error\nwant: %v\n got: %v", simulatedErr1, err)
+	}
 
-	converter := newConverter(spec, false)
-	if err := converter.Do(fw); !errors.Is(err, simulatedErr) {
-		t.Fatalf("unexpected error\nwant: %v\n got: %v", simulatedErr, err)
+	simulatedErr2 := errors.New("simulated error 2")
+	writerFactory = func(string) (io.WriteCloser, error) { return nil, simulatedErr2 }
+	converter = newConverter(spec, Config{})
+	if err := converter.Do(writerFactory); !errors.Is(err, simulatedErr2) {
+		t.Fatalf("unexpected error\nwant: %v\n got: %v", simulatedErr2, err)
 	}
 }

--- a/cmd/internal/genopenapi3/converter_helpers_test.go
+++ b/cmd/internal/genopenapi3/converter_helpers_test.go
@@ -3,6 +3,7 @@ package genopenapi3
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,8 +18,8 @@ import (
 type testCase struct {
 	inSpec              string
 	inSkipPrivateModels bool
-	outDoc              string   // excluding root keys 'openapi3' and 'info'
-	supportingSpecs     []string // other dependency specs needed for test case(s)
+	outDocs             map[string]string // docname -> rawDoc excluding root keys 'openapi3' and 'info'
+	supportingSpecs     []string          // other dependency specs needed for test case(s)
 }
 
 type testCaseRunner struct {
@@ -93,48 +94,69 @@ func (r *testCaseRunner) run(name string, tc testCase) {
 			t.Fatalf("error parsing spec set from test data: %v", err)
 		}
 
-		converter := newConverter(spec, tc.inSkipPrivateModels)
-		output := new(bytes.Buffer)
-		if err := converter.Do(output); err != nil {
+		cfg := Config{
+			Public: tc.inSkipPrivateModels,
+		}
+		converter := newConverter(spec, cfg)
+
+		output := map[string]*writeCloserMem{}
+		writerFactory := func(docName string) (io.WriteCloser, error) {
+			wr := &writeCloserMem{new(bytes.Buffer)}
+			output[docName] = wr
+			return wr, nil
+		}
+		if err := converter.Do(writerFactory); err != nil {
 			t.Fatalf("error converting spec to openapi3: %v", err)
 		}
 
-		actual := make(map[string]interface{})
-		if err := json.Unmarshal(output.Bytes(), &actual); err != nil {
-			t.Fatalf("invalid actual output data: malformed json content: %v", err)
+		if la, le := len(output), len(tc.outDocs); la != le {
+			t.Fatalf("expected %d output documents, got: %d", le, la)
+		}
+		for docName := range tc.outDocs {
+			if _, ok := output[docName]; !ok {
+				t.Fatalf("document with name '%s' does not exist in the actual output", docName)
+			}
 		}
 
-		expected := make(map[string]interface{})
-		if err := json.Unmarshal([]byte(tc.outDoc), &expected); err != nil {
-			t.Fatalf("invalid expected output data in test case: malformed json content: %v", err)
-		}
-		// root keys 'openapi3' and 'info' must be identical for all test cases;
-		// therefore, we inject them here or fail the test if they are defined
-		// to make test cases more readable and to prevent repeating them in all
-		// test cases, which is going to be boring
-		if _, ok := expected["openapi"]; ok {
-			t.Fatal("key 'openapi' must not be defined in the expected outDoc as it is set by the test")
-		}
-		if _, ok := expected["info"]; ok {
-			t.Fatal("key 'info' must not be defined in the expected outDoc as it is set by the test")
-		}
-		expected["openapi"] = "3.0.3"
-		expected["info"] = map[string]interface{}{
-			"contact": map[string]interface{}{
-				"email": "dev@aporeto.com",
-				"name":  "Aporeto Inc.",
-				"url":   "go.aporeto.io/api",
-			},
-			"license": map[string]interface{}{
-				"name": "TODO",
-			},
-			"termsOfService": "https://localhost/TODO",
-			"title":          "gaia",
-			"version":        "1.0",
-		}
+		for expectedDocName, expectedRawDoc := range tc.outDocs {
+			actualRawDoc := output[expectedDocName]
+			actual := make(map[string]interface{})
+			if err := json.Unmarshal(actualRawDoc.Bytes(), &actual); err != nil {
+				t.Fatalf("invalid actual output data: malformed json content: %v", err)
+			}
 
-		if diff := deep.Equal(actual, expected); diff != nil {
-			t.Fatal("actual != expected output\n", strings.Join(diff, "\n"))
+			expected := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(expectedRawDoc), &expected); err != nil {
+				t.Fatalf("invalid expected output data in test case: malformed json content: %v", err)
+			}
+			// root keys 'openapi3' and 'info' must be identical for all test cases;
+			// therefore, we inject them here or fail the test if they are defined
+			// to make test cases more readable and to prevent repeating them in all
+			// test cases, which is going to be boring
+			if _, ok := expected["openapi"]; ok {
+				t.Fatal("key 'openapi' must not be defined in the expected outDoc as it is set by the test")
+			}
+			if _, ok := expected["info"]; ok {
+				t.Fatal("key 'info' must not be defined in the expected outDoc as it is set by the test")
+			}
+			expected["openapi"] = "3.0.3"
+			expected["info"] = map[string]interface{}{
+				"contact": map[string]interface{}{
+					"email": "dev@aporeto.com",
+					"name":  "Aporeto Inc.",
+					"url":   "go.aporeto.io/api",
+				},
+				"license": map[string]interface{}{
+					"name": "TODO",
+				},
+				"termsOfService": "https://localhost/TODO",
+				"title":          "gaia",
+				"version":        "1.0",
+			}
+
+			if diff := deep.Equal(actual, expected); diff != nil {
+				t.Fatal("actual != expected output\n", strings.Join(diff, "\n"))
+			}
 		}
 	})
 }
@@ -165,9 +187,22 @@ func replaceTrailingTabsWithDoubleSpaceForYAML(s string) string {
 }
 
 type fakeWriter struct {
-	err error
+	wrErr error
+	cErr  error
 }
 
 func (fw *fakeWriter) Write([]byte) (int, error) {
-	return 0, fw.err
+	return 0, fw.wrErr
+}
+
+func (fw *fakeWriter) Close() error {
+	return fw.cErr
+}
+
+type writeCloserMem struct {
+	*bytes.Buffer
+}
+
+func (wr *writeCloserMem) Close() error {
+	return nil
 }

--- a/cmd/internal/genopenapi3/converter_helpers_test.go
+++ b/cmd/internal/genopenapi3/converter_helpers_test.go
@@ -18,6 +18,7 @@ import (
 type testCase struct {
 	inSpec              string
 	inSkipPrivateModels bool
+	inSplitOutput       bool
 	outDocs             map[string]string // docname -> rawDoc excluding root keys 'openapi3' and 'info'
 	supportingSpecs     []string          // other dependency specs needed for test case(s)
 }
@@ -95,7 +96,8 @@ func (r *testCaseRunner) run(name string, tc testCase) {
 		}
 
 		cfg := Config{
-			Public: tc.inSkipPrivateModels,
+			Public:      tc.inSkipPrivateModels,
+			SplitOutput: tc.inSplitOutput,
 		}
 		converter := newConverter(spec, cfg)
 

--- a/cmd/internal/genopenapi3/converter_model_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_model_nonroot_test.go
@@ -19,18 +19,20 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 					group: N/A
 					description: empty model.
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"void": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"void": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"attribute-ignored-if-unexposed": {
@@ -49,18 +51,20 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						type: integer
 						exposed: false
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"model-is-ignored-if-private-and-skip-flag-is-set": {
@@ -81,12 +85,14 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						type: integer
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {},
-					"paths": {}
-				}
-			`,
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"primitive-attributes": {
@@ -121,41 +127,43 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						type: time
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"stringField": {
-										"description": "useful description for string.",
-										"type": "string"
-									},
-									"intField": {
-										"description": "useful description for integer.",
-										"type": "integer"
-									},
-									"floatField": {
-										"description": "useful description for float.",
-										"type": "number"
-									},
-									"booleanField": {
-										"description": "useful description for boolean.",
-										"type": "boolean"
-									},
-									"timeField": {
-										"description": "useful description for time.",
-										"type": "string",
-										"format": "date-time"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"stringField": {
+											"description": "useful description for string.",
+											"type": "string"
+										},
+										"intField": {
+											"description": "useful description for integer.",
+											"type": "integer"
+										},
+										"floatField": {
+											"description": "useful description for float.",
+											"type": "number"
+										},
+										"booleanField": {
+											"description": "useful description for boolean.",
+											"type": "boolean"
+										},
+										"timeField": {
+											"description": "useful description for time.",
+											"type": "string",
+											"format": "date-time"
+										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"enum-attribute": {
@@ -177,24 +185,26 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 							- Choice2
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"someField": {
-										"description": "useful description.",
-										"enum": ["Choice1", "Choice2"]
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"someField": {
+											"description": "useful description.",
+											"enum": ["Choice1", "Choice2"]
+										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"object-attribute": {
@@ -213,24 +223,26 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						type: object
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"someField": {
-										"description": "useful description.",
-										"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"someField": {
+											"description": "useful description.",
+											"type": "object"
+										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"list-of-primitive-attributes": {
@@ -270,56 +282,58 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						subtype: time
 						exposed: true
 				`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"stringListField": {
-										"description": "useful stringListField description.",
-										"type": "array",
-										"items": {
-											"type": "string"
-										}
-									},
-									"integerListField": {
-										"description": "useful integerListField description.",
-										"type": "array",
-										"items": {
-											"type": "integer"
-										}
-									},
-									"floatListField": {
-										"description": "useful floatListField description.",
-										"type": "array",
-										"items": {
-											"type": "number"
-										}
-									},
-									"booleanListField": {
-										"description": "useful booleanListField description.",
-										"type": "array",
-										"items": {
-											"type": "boolean"
-										}
-									},
-									"timeListField": {
-										"description": "useful timeListField description.",
-										"type": "array",
-										"items": {
-											"type": "string",
-											"format": "date-time"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"stringListField": {
+											"description": "useful stringListField description.",
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										},
+										"integerListField": {
+											"description": "useful integerListField description.",
+											"type": "array",
+											"items": {
+												"type": "integer"
+											}
+										},
+										"floatListField": {
+											"description": "useful floatListField description.",
+											"type": "array",
+											"items": {
+												"type": "number"
+											}
+										},
+										"booleanListField": {
+											"description": "useful booleanListField description.",
+											"type": "array",
+											"items": {
+												"type": "boolean"
+											}
+										},
+										"timeListField": {
+											"description": "useful timeListField description.",
+											"type": "array",
+											"items": {
+												"type": "string",
+												"format": "date-time"
+											}
 										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		// we assume any referenced type is already defined in 'components.schemas'
@@ -340,23 +354,25 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						subtype: imaginary
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"someField": {
-										"$ref": "#/components/schemas/imaginary"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"someField": {
+											"$ref": "#/components/schemas/imaginary"
+										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		// we assume any referenced type is already defined in 'components.schemas'
@@ -382,34 +398,36 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						subtype: imaginary2
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"someField1": {
-										"description": "useful someField1 description.",
-										"type": "array",
-										"items": {
-											"$ref": "#/components/schemas/imaginary1"
-										}
-									},
-									"someField2": {
-										"description": "useful someField2 description.",
-										"type": "array",
-										"items": {
-											"$ref": "#/components/schemas/imaginary2"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"someField1": {
+											"description": "useful someField1 description.",
+											"type": "array",
+											"items": {
+												"$ref": "#/components/schemas/imaginary1"
+											}
+										},
+										"someField2": {
+											"description": "useful someField2 description.",
+											"type": "array",
+											"items": {
+												"$ref": "#/components/schemas/imaginary2"
+											}
 										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		// we assume any referenced type is already defined in 'components.schemas'
@@ -435,34 +453,36 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						subtype: imaginary2
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"someField1": {
-										"description": "useful someField1 description.",
-										"type": "object",
-										"additionalProperties": {
-											"$ref": "#/components/schemas/imaginary1"
-										}
-									},
-									"someField2": {
-										"description": "useful someField2 description.",
-										"type": "object",
-										"additionalProperties": {
-											"$ref": "#/components/schemas/imaginary2"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"someField1": {
+											"description": "useful someField1 description.",
+											"type": "object",
+											"additionalProperties": {
+												"$ref": "#/components/schemas/imaginary1"
+											}
+										},
+										"someField2": {
+											"description": "useful someField2 description.",
+											"type": "object",
+											"additionalProperties": {
+												"$ref": "#/components/schemas/imaginary2"
+											}
 										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"attributes-with-external-type--[]byte-turns-into-string": {
@@ -482,24 +502,26 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						subtype: '[]byte'
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"properties": {
-									"someField": {
-										"description": "useful description.",
-										"type": "string"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"properties": {
+										"someField": {
+											"description": "useful description.",
+											"type": "string"
+										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 
 		"required-attributes": {
@@ -524,30 +546,32 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 						type: integer
 						exposed: true
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"test": {
-								"type": "object",
-								"required": ["stringField"],
-								"properties": {
-									"stringField": {
-										"description": "useful description for string.",
-										"default": "hello-world",
-										"type": "string"
-									},
-									"intField": {
-										"description": "useful description for integer.",
-										"type": "integer"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"test": {
+									"type": "object",
+									"required": ["stringField"],
+									"properties": {
+										"stringField": {
+											"description": "useful description for string.",
+											"default": "hello-world",
+											"type": "string"
+										},
+										"intField": {
+											"description": "useful description for integer.",
+											"type": "integer"
+										}
 									}
 								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 		},
 	}
 	runAllTestCases(t, cases)

--- a/cmd/internal/genopenapi3/converter_model_root_test.go
+++ b/cmd/internal/genopenapi3/converter_model_root_test.go
@@ -20,12 +20,14 @@ func TestConverter_Do__model_root(t *testing.T) {
 					group: core
 					description: root object.
 			`,
-			outDoc: `
-				{
-					"components": {},
-					"paths": {}
-				}
-			`,
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {},
+						"paths": {}
+					}
+				`,
+			},
 		},
 	}
 	runAllTestCases(t, cases)

--- a/cmd/internal/genopenapi3/converter_relations_model_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_model_nonroot_test.go
@@ -27,49 +27,51 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								description: This is a fancy parameter that should appear only once.
 								type: time
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
-							}
-						}
-					},
-					"paths": {
-						"/resources/{id}": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
 								}
-							],
-							"get": {
-								"operationId": "get-resource-by-ID",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Retrieves the resource with the given ID.",
+							}
+						},
+						"paths": {
+							"/resources/{id}": {
 								"parameters": [
 									{
-										"description": "This is a fancy parameter that should appear only once.",
-										"in": "query",
-										"name": "duplicateParam",
+										"in": "path",
+										"name": "id",
+										"required": true,
 										"schema": {
-											"type": "string",
-											"format": "date-time"
+											"type": "string"
 										}
 									}
 								],
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"$ref": "#/components/schemas/resource"
+								"get": {
+									"operationId": "get-resource-by-ID",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Retrieves the resource with the given ID.",
+									"parameters": [
+										{
+											"description": "This is a fancy parameter that should appear only once.",
+											"in": "query",
+											"name": "duplicateParam",
+											"schema": {
+												"type": "string",
+												"format": "date-time"
+											}
+										}
+									],
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
 												}
 											}
 										}
@@ -78,8 +80,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 		},
 
 		"delete-by-ID": {
@@ -99,48 +101,50 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								description: This is a fancy parameter.
 								type: duration
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
-							}
-						}
-					},
-					"paths": {
-						"/resources/{id}": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
 								}
-							],
-							"delete": {
-								"operationId": "delete-resource-by-ID",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Deletes the resource with the given ID.",
+							}
+						},
+						"paths": {
+							"/resources/{id}": {
 								"parameters": [
 									{
-										"description": "This is a fancy parameter.",
-										"in": "query",
-										"name": "fancyParam",
+										"in": "path",
+										"name": "id",
+										"required": true,
 										"schema": {
 											"type": "string"
 										}
 									}
 								],
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"$ref": "#/components/schemas/resource"
+								"delete": {
+									"operationId": "delete-resource-by-ID",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Deletes the resource with the given ID.",
+									"parameters": [
+										{
+											"description": "This is a fancy parameter.",
+											"in": "query",
+											"name": "fancyParam",
+											"schema": {
+												"type": "string"
+											}
+										}
+									],
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
 												}
 											}
 										}
@@ -149,8 +153,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 		},
 
 		"put-by-ID": {
@@ -173,57 +177,59 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 								- Choice1
 								- Choice2
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
-							}
-						}
-					},
-					"paths": {
-						"/resources/{id}": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
 								}
-							],
-							"put": {
-								"operationId": "update-resource-by-ID",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Updates the resource with the given ID.",
+							}
+						},
+						"paths": {
+							"/resources/{id}": {
 								"parameters": [
 									{
-										"description": "This is a fancy parameter.",
-										"in": "query",
-										"name": "fancyParam",
+										"in": "path",
+										"name": "id",
+										"required": true,
 										"schema": {
-											"enum": ["Choice1", "Choice2"]
+											"type": "string"
 										}
 									}
 								],
-								"requestBody": {
-									"content": {
-										"application/json": {
+								"put": {
+									"operationId": "update-resource-by-ID",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Updates the resource with the given ID.",
+									"parameters": [
+										{
+											"description": "This is a fancy parameter.",
+											"in": "query",
+											"name": "fancyParam",
 											"schema": {
-												"$ref": "#/components/schemas/resource"
+												"enum": ["Choice1", "Choice2"]
 											}
 										}
-									}
-								},
-								"responses": {
-									"200": {
-										"description": "n/a",
+									],
+									"requestBody": {
 										"content": {
 											"application/json": {
 												"schema": {
 													"$ref": "#/components/schemas/resource"
+												}
+											}
+										}
+									},
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
 												}
 											}
 										}
@@ -232,8 +238,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 		},
 
 		"get-put-delete-by-ID--do-not-duplicate-param-ID": {
@@ -252,81 +258,83 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 					update:
 						description: Updates the resource with the given ID.
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {
-						"/resources/{id}": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
-								}
-							],
-							"get": {
-								"operationId": "get-resource-by-ID",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Retrieves the resource with the given ID.",
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"$ref": "#/components/schemas/resource"
-												}
-											}
+						},
+						"paths": {
+							"/resources/{id}": {
+								"parameters": [
+									{
+										"in": "path",
+										"name": "id",
+										"required": true,
+										"schema": {
+											"type": "string"
 										}
 									}
-								}
-							},
-							"delete": {
-								"operationId": "delete-resource-by-ID",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Deletes the resource with the given ID.",
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"$ref": "#/components/schemas/resource"
+								],
+								"get": {
+									"operationId": "get-resource-by-ID",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Retrieves the resource with the given ID.",
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
 												}
-											}
-										}
-									}
-								}
-							},
-							"put": {
-								"operationId": "update-resource-by-ID",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Updates the resource with the given ID.",
-								"requestBody": {
-									"content": {
-										"application/json": {
-											"schema": {
-												"$ref": "#/components/schemas/resource"
 											}
 										}
 									}
 								},
-								"responses": {
-									"200": {
-										"description": "n/a",
+								"delete": {
+									"operationId": "delete-resource-by-ID",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Deletes the resource with the given ID.",
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
+												}
+											}
+										}
+									}
+								},
+								"put": {
+									"operationId": "update-resource-by-ID",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Updates the resource with the given ID.",
+									"requestBody": {
 										"content": {
 											"application/json": {
 												"schema": {
 													"$ref": "#/components/schemas/resource"
+												}
+											}
+										}
+									},
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
 												}
 											}
 										}
@@ -335,8 +343,8 @@ func TestConverter_Do__modelRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 		},
 	}
 	runAllTestCases(t, cases)

--- a/cmd/internal/genopenapi3/converter_relations_spec_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_spec_nonroot_test.go
@@ -31,63 +31,65 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 								type: string
 								default_value: "this is a value 2"
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"minesite": {
-								"type": "object"
-							},
-							"resource": {
-								"type": "object"
-							}
-						}
-					},
-					"paths": {
-						"/resources/{id}/minesites": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"minesite": {
+									"type": "object"
+								},
+								"resource": {
+									"type": "object"
 								}
-							],
-							"get": {
-								"operationId": "get-all-minesites-for-a-given-resource",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Retrieve all mine sites.",
+							}
+						},
+						"paths": {
+							"/resources/{id}/minesites": {
 								"parameters": [
 									{
-										"description": "should appear at the beginning.",
-										"in": "query",
-										"name": "aParam",
+										"in": "path",
+										"name": "id",
+										"required": true,
 										"schema": {
 											"type": "string"
-										},
-										"example": "this is a value 2"
-									},
-									{
-										"description": "This is a fancy parameter.",
-										"in": "query",
-										"name": "fancyParam",
-										"schema": {
-											"type": "string"
-										},
-										"example": "this is a value"
+										}
 									}
 								],
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"type": "array",
-													"items": {
-														"$ref": "#/components/schemas/minesite"
+								"get": {
+									"operationId": "get-all-minesites-for-a-given-resource",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Retrieve all mine sites.",
+									"parameters": [
+										{
+											"description": "should appear at the beginning.",
+											"in": "query",
+											"name": "aParam",
+											"schema": {
+												"type": "string"
+											},
+											"example": "this is a value 2"
+										},
+										{
+											"description": "This is a fancy parameter.",
+											"in": "query",
+											"name": "fancyParam",
+											"schema": {
+												"type": "string"
+											},
+											"example": "this is a value"
+										}
+									],
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"type": "array",
+														"items": {
+															"$ref": "#/components/schemas/minesite"
+														}
 													}
 												}
 											}
@@ -97,8 +99,8 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: minesite
@@ -132,60 +134,62 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 
 
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"minesite": {
-								"type": "object"
-							},
-							"resource": {
-								"type": "object"
-							}
-						}
-					},
-					"paths": {
-						"/resources/{id}/minesites": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"minesite": {
+									"type": "object"
+								},
+								"resource": {
+									"type": "object"
 								}
-							],
-							"post": {
-								"operationId": "create-a-new-minesite-for-a-given-resource",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Creates a mine site.",
+							}
+						},
+						"paths": {
+							"/resources/{id}/minesites": {
 								"parameters": [
 									{
-										"description": "This is a fancy parameter.",
-										"in": "query",
-										"name": "fancyParam",
+										"in": "path",
+										"name": "id",
+										"required": true,
 										"schema": {
-											"type": "number"
+											"type": "string"
 										}
 									}
 								],
-								"requestBody": {
-									"content": {
-										"application/json": {
+								"post": {
+									"operationId": "create-a-new-minesite-for-a-given-resource",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Creates a mine site.",
+									"parameters": [
+										{
+											"description": "This is a fancy parameter.",
+											"in": "query",
+											"name": "fancyParam",
 											"schema": {
-												"$ref": "#/components/schemas/minesite"
+												"type": "number"
 											}
 										}
-									}
-								},
-								"responses": {
-									"200": {
-										"description": "n/a",
+									],
+									"requestBody": {
 										"content": {
 											"application/json": {
 												"schema": {
 													"$ref": "#/components/schemas/minesite"
+												}
+											}
+										}
+									},
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/minesite"
+													}
 												}
 											}
 										}
@@ -194,8 +198,8 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: minesite
@@ -220,21 +224,23 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 				relations:
 				- rest_name: minesite
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"minesite": {
-								"type": "object"
-							},
-							"resource": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"minesite": {
+									"type": "object"
+								},
+								"resource": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: minesite
@@ -263,46 +269,36 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 					create:
 						description: Creates a mine site.
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"minesite": {
-								"type": "object"
-							},
-							"resource": {
-								"type": "object"
-							}
-						}
-					},
-					"paths": {
-						"/resources/{id}/minesites": {
-							"parameters": [
-								{
-									"in": "path",
-									"name": "id",
-									"required": true,
-									"schema": {
-										"type": "string"
-									}
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"minesite": {
+									"type": "object"
+								},
+								"resource": {
+									"type": "object"
 								}
-							],
-							"post": {
-								"operationId": "create-a-new-minesite-for-a-given-resource",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Creates a mine site.",
-								"requestBody": {
-									"content": {
-										"application/json": {
-											"schema": {
-												"$ref": "#/components/schemas/minesite"
-											}
+							}
+						},
+						"paths": {
+							"/resources/{id}/minesites": {
+								"parameters": [
+									{
+										"in": "path",
+										"name": "id",
+										"required": true,
+										"schema": {
+											"type": "string"
 										}
 									}
-								},
-								"responses": {
-									"200": {
-										"description": "n/a",
+								],
+								"post": {
+									"operationId": "create-a-new-minesite-for-a-given-resource",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Creates a mine site.",
+									"requestBody": {
 										"content": {
 											"application/json": {
 												"schema": {
@@ -310,22 +306,34 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 												}
 											}
 										}
-									}
-								}
-							},
-							"get": {
-								"operationId": "get-all-minesites-for-a-given-resource",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Retrieve all mine sites.",
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"type": "array",
-													"items": {
+									},
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
 														"$ref": "#/components/schemas/minesite"
+													}
+												}
+											}
+										}
+									}
+								},
+								"get": {
+									"operationId": "get-all-minesites-for-a-given-resource",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Retrieve all mine sites.",
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"type": "array",
+														"items": {
+															"$ref": "#/components/schemas/minesite"
+														}
 													}
 												}
 											}
@@ -335,8 +343,8 @@ func TestConverter_Do__specRelations_nonRoot(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: minesite

--- a/cmd/internal/genopenapi3/converter_relations_spec_root_test.go
+++ b/cmd/internal/genopenapi3/converter_relations_spec_root_test.go
@@ -30,47 +30,49 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 								description: This is a fancy parameter.
 								type: integer
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {
-						"/resources": {
-							"post": {
-								"operationId": "create-a-new-resource",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"parameters": [
-									{
-										"description": "This is a fancy parameter.",
-										"in": "query",
-										"name": "fancyParam",
-										"schema": {
-											"type": "integer"
-										}
-									}
-								],
-								"description": "Creates some resource.",
-								"requestBody": {
-									"content": {
-										"application/json": {
+						},
+						"paths": {
+							"/resources": {
+								"post": {
+									"operationId": "create-a-new-resource",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"parameters": [
+										{
+											"description": "This is a fancy parameter.",
+											"in": "query",
+											"name": "fancyParam",
 											"schema": {
-												"$ref": "#/components/schemas/resource"
+												"type": "integer"
 											}
 										}
-									}
-								},
-								"responses": {
-									"200": {
-										"description": "n/a",
+									],
+									"description": "Creates some resource.",
+									"requestBody": {
 										"content": {
 											"application/json": {
 												"schema": {
 													"$ref": "#/components/schemas/resource"
+												}
+											}
+										}
+									},
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"$ref": "#/components/schemas/resource"
+													}
 												}
 											}
 										}
@@ -79,8 +81,8 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: resource
@@ -113,40 +115,42 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 						    description: This is a fancy parameter.
 						    type: boolean
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {
-						"/resources": {
-							"get": {
-								"operationId": "get-all-resources",
-								"tags": ["useful/thing", "usefulPackageName"],
-								"description": "Retrieve all resources.",
-								"parameters": [
-								  {
-								    "description": "This is a fancy parameter.",
-								    "in": "query",
-								    "name": "fancyParam",
-								    "schema": {
-								      "type": "boolean"
-								    }
-								  }
-								],
-								"responses": {
-									"200": {
-										"description": "n/a",
-										"content": {
-											"application/json": {
-												"schema": {
-													"type": "array",
-													"items": {
-														"$ref": "#/components/schemas/resource"
+						},
+						"paths": {
+							"/resources": {
+								"get": {
+									"operationId": "get-all-resources",
+									"tags": ["useful/thing", "usefulPackageName"],
+									"description": "Retrieve all resources.",
+									"parameters": [
+									  {
+									    "description": "This is a fancy parameter.",
+									    "in": "query",
+									    "name": "fancyParam",
+									    "schema": {
+									      "type": "boolean"
+									    }
+									  }
+									],
+									"responses": {
+										"200": {
+											"description": "n/a",
+											"content": {
+												"application/json": {
+													"schema": {
+														"type": "array",
+														"items": {
+															"$ref": "#/components/schemas/resource"
+														}
 													}
 												}
 											}
@@ -156,8 +160,8 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 							}
 						}
 					}
-				}
-			`,
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: resource
@@ -183,18 +187,20 @@ func TestConverter_Do__specRelations_root(t *testing.T) {
 				relations:
 				- rest_name: resource
 			`,
-			outDoc: `
-				{
-					"components": {
-						"schemas": {
-							"resource": {
-								"type": "object"
+			outDocs: map[string]string{
+				"toplevel": `
+					{
+						"components": {
+							"schemas": {
+								"resource": {
+									"type": "object"
+								}
 							}
-						}
-					},
-					"paths": {}
-				}
-			`,
+						},
+						"paths": {}
+					}
+				`,
+			},
 			supportingSpecs: []string{`
 				model:
 					rest_name: resource

--- a/cmd/internal/genopenapi3/converter_split_output_test.go
+++ b/cmd/internal/genopenapi3/converter_split_output_test.go
@@ -1,0 +1,34 @@
+package genopenapi3
+
+import "testing"
+
+func TestConverter_Do__splitOutput_emptyRootModel(t *testing.T) {
+	t.Parallel()
+
+	inSpec := `
+		model:
+			root: true
+			rest_name: root
+			resource_name: root
+			entity_name: Root
+			package: root
+			group: core
+			description: root object.
+	`
+	outDocs := `
+		{
+			"components": {},
+			"paths": {}
+		}
+	`
+
+	testCaseWrapper := map[string]testCase{
+		"empty-toplevel-single-output": {
+			inSplitOutput: true,
+			inSpec:        inSpec,
+			outDocs:       map[string]string{"toplevel": outDocs},
+		},
+	}
+	runAllTestCases(t, testCaseWrapper)
+}
+

--- a/cmd/internal/genopenapi3/converter_split_output_test.go
+++ b/cmd/internal/genopenapi3/converter_split_output_test.go
@@ -32,3 +32,330 @@ func TestConverter_Do__splitOutput_emptyRootModel(t *testing.T) {
 	runAllTestCases(t, testCaseWrapper)
 }
 
+func TestConverter_Do__split_output_complex(t *testing.T) {
+	t.Parallel()
+
+	inSpec := `
+		model:
+			root: true
+			rest_name: root
+			resource_name: root
+			entity_name: Root
+			package: root
+			group: core
+			description: root object.
+
+		relations:
+		- rest_name: minesite
+			get:
+				description: Retrieves all minesites.
+			create:
+				description: Creates a new minesite.
+	`
+
+	supportingSpecs := []string{
+		`
+		model:
+			rest_name: minesite
+			resource_name: minesites
+			entity_name: MineSites
+			package: usefulPackageName
+			group: useful/thing
+			description: Represents a resource mine site.
+			get:
+				description: Retrieves a mine site by ID.
+			update:
+				description: Updates a mine site by ID.
+			delete:
+				description: Delete a minesite by ID.
+
+		relations:
+		- rest_name: resource
+			get:
+				description: Retrieves a list of resources for a given mine site.
+			create:
+				description: assign a new resource for a given mine site.
+		`,
+		`
+		model:
+			rest_name: resource
+			resource_name: resources
+			entity_name: Resources
+			package: naturalResources
+			group: oil/gas
+			description: Represents a natural resource.
+		attributes:
+			v1:
+			- name: supervisor
+				description: The supervisor of this natural resource.
+				exposed: true
+				type: ref
+				subtype: employee
+		`,
+		`
+		model:
+			rest_name: employee
+			resource_name: employees
+			entity_name: Employees
+			package: people
+			group: employee/affairs
+			description: Represents a full-time employee.
+		`,
+	}
+
+	outDocs := map[string]string{
+		"minesite": `
+			{
+				"components": {
+					"schemas": {
+						"minesite": {
+							"type": "object"
+						}
+					}
+				},
+				"paths": {
+					"/minesites": {
+						"get": {
+							"description": "Retrieves all minesites.",
+							"operationId": "get-all-minesites",
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"items": {
+													"$ref": "#/components/schemas/minesite"
+												},
+												"type": "array"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"useful/thing",
+								"usefulPackageName"
+							]
+						},
+						"post": {
+							"description": "Creates a new minesite.",
+							"operationId": "create-a-new-minesite",
+							"requestBody": {
+								"content": {
+									"application/json": {
+										"schema": {
+											"$ref": "#/components/schemas/minesite"
+										}
+									}
+								}
+							},
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"$ref": "#/components/schemas/minesite"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"useful/thing",
+								"usefulPackageName"
+							]
+						}
+					},
+					"/minesites/{id}": {
+						"delete": {
+							"description": "Delete a minesite by ID.",
+							"operationId": "delete-minesite-by-ID",
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"$ref": "#/components/schemas/minesite"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"useful/thing",
+								"usefulPackageName"
+							]
+						},
+						"get": {
+							"description": "Retrieves a mine site by ID.",
+							"operationId": "get-minesite-by-ID",
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"$ref": "#/components/schemas/minesite"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"useful/thing",
+								"usefulPackageName"
+							]
+						},
+						"parameters": [
+							{
+								"in": "path",
+								"name": "id",
+								"required": true,
+								"schema": {
+									"type": "string"
+								}
+							}
+						],
+						"put": {
+							"description": "Updates a mine site by ID.",
+							"operationId": "update-minesite-by-ID",
+							"requestBody": {
+								"content": {
+									"application/json": {
+										"schema": {
+											"$ref": "#/components/schemas/minesite"
+										}
+									}
+								}
+							},
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"$ref": "#/components/schemas/minesite"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"useful/thing",
+								"usefulPackageName"
+							]
+						}
+					},
+					"/minesites/{id}/resources": {
+						"get": {
+							"description": "Retrieves a list of resources for a given mine site.",
+							"operationId": "get-all-resources-for-a-given-minesite",
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"items": {
+													"$ref": "./resource#/components/schemas/resource"
+												},
+												"type": "array"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"oil/gas",
+								"naturalResources"
+							]
+						},
+						"parameters": [
+							{
+								"in": "path",
+								"name": "id",
+								"required": true,
+								"schema": {
+									"type": "string"
+								}
+							}
+						],
+						"post": {
+							"description": "assign a new resource for a given mine site.",
+							"operationId": "create-a-new-resource-for-a-given-minesite",
+							"requestBody": {
+								"content": {
+									"application/json": {
+										"schema": {
+											"$ref": "./resource#/components/schemas/resource"
+										}
+									}
+								}
+							},
+							"responses": {
+								"200": {
+									"content": {
+										"application/json": {
+											"schema": {
+												"$ref": "./resource#/components/schemas/resource"
+											}
+										}
+									},
+									"description": "n/a"
+								}
+							},
+							"tags": [
+								"oil/gas",
+								"naturalResources"
+							]
+						}
+					}
+				}
+			}
+		`,
+
+		"resource": `
+			{
+				"components": {
+					"schemas": {
+						"resource": {
+							"properties": {
+								"supervisor": {
+									"$ref": "./employee#/components/schemas/employee"
+								}
+							},
+							"type": "object"
+						}
+					}
+				},
+				"paths": {}
+			}
+		`,
+
+		"employee": `
+			{
+				"components": {
+					"schemas": {
+						"employee": {
+							"type": "object"
+						}
+					}
+				},
+				"paths": {}
+			}
+		`,
+	}
+
+	testCaseWrapper := map[string]testCase{
+		"multiple-models-and-relations": {
+			inSplitOutput:   true,
+			inSpec:          inSpec,
+			supportingSpecs: supportingSpecs,
+			outDocs:         outDocs,
+		},
+	}
+	runAllTestCases(t, testCaseWrapper)
+}

--- a/cmd/internal/genopenapi3/exports.go
+++ b/cmd/internal/genopenapi3/exports.go
@@ -2,6 +2,7 @@ package genopenapi3
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -9,10 +10,15 @@ import (
 	"go.aporeto.io/regolithe/spec"
 )
 
-// GeneratorFunc implements the signature defined by regolithe to convert spec to openapi3 doc
-func GeneratorFunc(sets []spec.SpecificationSet, out string, public bool) error {
+type Config struct {
+	Public      bool
+	SplitOutput bool
+	OutputDir   string
+}
 
-	outFolder := path.Join(out, "openapi3")
+func GeneratorFunc(sets []spec.SpecificationSet, cfg Config) error {
+
+	outFolder := path.Join(cfg.OutputDir, "openapi3")
 	if err := os.MkdirAll(outFolder, 0750); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("'%s': error creating directory: %w", outFolder, err)
 	}
@@ -27,7 +33,7 @@ func GeneratorFunc(sets []spec.SpecificationSet, out string, public bool) error 
 	}
 
 	set := sets[0]
-	converter := newConverter(set, public)
+	converter := newConverter(set, cfg)
 	if err := converter.Do(fileFactory); err != nil {
 		return fmt.Errorf("error generating openapi3 document from spec set '%s': %w", set.Configuration().Name, err)
 	}

--- a/cmd/internal/genopenapi3/exports.go
+++ b/cmd/internal/genopenapi3/exports.go
@@ -17,15 +17,18 @@ func GeneratorFunc(sets []spec.SpecificationSet, out string, public bool) error 
 		return fmt.Errorf("'%s': error creating directory: %w", outFolder, err)
 	}
 
-	filename := filepath.Join(outFolder, "toplevel.json")
-	file, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("'%s': error creating file: %w", filename, err)
+	fileFactory := func(name string) (io.WriteCloser, error) {
+		filename := filepath.Join(outFolder, name)
+		file, err := os.Create(filename)
+		if err != nil {
+			return nil, fmt.Errorf("'%s': error creating file: %w", filename, err)
+		}
+		return file, nil
 	}
 
 	set := sets[0]
 	converter := newConverter(set, public)
-	if err = converter.Do(file); err != nil {
+	if err := converter.Do(fileFactory); err != nil {
 		return fmt.Errorf("error generating openapi3 document from spec set '%s': %w", set.Configuration().Name, err)
 	}
 

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -25,27 +25,7 @@ func newConverter(inSpecSet spec.SpecificationSet, skipPrivateModels bool) *conv
 		skipPrivateModels: skipPrivateModels,
 		inSpecSet:         inSpecSet,
 		resourceToRest:    make(map[string]string),
-		outRootDoc: openapi3.T{
-			OpenAPI: "3.0.3",
-			Info: &openapi3.Info{
-				Title:          specConfig.Name,
-				Version:        specConfig.Version,
-				Description:    specConfig.Description,
-				TermsOfService: "https://localhost/TODO", // TODO
-				License: &openapi3.License{
-					Name: "TODO",
-				},
-				Contact: &openapi3.Contact{
-					Name:  specConfig.Author,
-					URL:   specConfig.URL,
-					Email: specConfig.Email,
-				},
-			},
-			Paths: openapi3.Paths{},
-			Components: openapi3.Components{
-				Schemas: make(openapi3.Schemas),
-			},
-		},
+		outRootDoc:        newOpenAPI3Template(inSpecSet.Configuration()),
 	}
 
 	for _, spec := range inSpecSet.Specifications() {
@@ -107,4 +87,28 @@ func (c *converter) processSpec(s spec.Specification) error {
 	}
 
 	return nil
+}
+
+func newOpenAPI3Template(specConfig *spec.Config) openapi3.T {
+	return openapi3.T{
+		OpenAPI: "3.0.3",
+		Info: &openapi3.Info{
+			Title:          specConfig.Name,
+			Version:        specConfig.Version,
+			Description:    specConfig.Description,
+			TermsOfService: "https://localhost/TODO", // TODO
+			License: &openapi3.License{
+				Name: "TODO",
+			},
+			Contact: &openapi3.Contact{
+				Name:  specConfig.Author,
+				URL:   specConfig.URL,
+				Email: specConfig.Email,
+			},
+		},
+		Paths: openapi3.Paths{},
+		Components: openapi3.Components{
+			Schemas: make(openapi3.Schemas),
+		},
+	}
 }

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -67,20 +67,21 @@ func (c *converter) convertedDocs() map[string]openapi3.T {
 		return map[string]openapi3.T{"toplevel": c.outRootDoc}
 	}
 
-	out := make(map[string]openapi3.T)
+	docs := make(map[string]openapi3.T)
 	specConfig := c.inSpecSet.Configuration()
 	for name, schema := range c.outRootDoc.Components.Schemas {
 		template := newOpenAPI3Template(specConfig)
 		template.Components.Schemas[name] = schema
-		out[name] = template
+		docs[name] = template
 	}
 
 	for path, item := range c.outRootDoc.Paths {
-		home := strings.Split(strings.Trim(path, "/"), "/")[0]
-		home = c.resourceToRest[home]
-		out[home].Paths[path] = item
+		pathRoot := strings.SplitN(strings.Trim(path, "/"), "/", 2)[0]
+		docName := c.resourceToRest[pathRoot]
+		docs[docName].Paths[path] = item
 	}
-	return out
+
+	return docs
 }
 
 func (c *converter) processSpec(s spec.Specification) error {

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -13,6 +13,7 @@ const paramNameID = "id"
 
 type converter struct {
 	skipPrivateModels bool
+	splitOutput       bool
 	inSpecSet         spec.SpecificationSet
 	resourceToRest    map[string]string
 	outRootDoc        openapi3.T

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"go.aporeto.io/regolithe/spec"
@@ -19,10 +20,10 @@ type converter struct {
 	outRootDoc        openapi3.T
 }
 
-func newConverter(inSpecSet spec.SpecificationSet, skipPrivateModels bool) *converter {
-	specConfig := inSpecSet.Configuration()
+func newConverter(inSpecSet spec.SpecificationSet, cfg Config) *converter {
 	c := &converter{
-		skipPrivateModels: skipPrivateModels,
+		skipPrivateModels: cfg.Public,
+		splitOutput:       cfg.SplitOutput,
 		inSpecSet:         inSpecSet,
 		resourceToRest:    make(map[string]string),
 		outRootDoc:        newOpenAPI3Template(inSpecSet.Configuration()),

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -63,7 +63,7 @@ func (c *converter) Do(newWriter func(name string) (io.WriteCloser, error)) erro
 
 func (c *converter) convertedDocs() map[string]openapi3.T {
 
-	if !c.splitOutput {
+	if !c.splitOutput || len(c.outRootDoc.Components.Schemas) == 0 {
 		return map[string]openapi3.T{"toplevel": c.outRootDoc}
 	}
 

--- a/cmd/internal/genopenapi3/gen_model.go
+++ b/cmd/internal/genopenapi3/gen_model.go
@@ -89,6 +89,9 @@ func (c *converter) convertAttribute(attr *spec.Attribute) (schemaRef *openapi3.
 		return attrSchema.NewRef(), err // do not wrap error to avoid recursive wrapping
 
 	case spec.AttributeTypeRef:
+		if c.splitOutput {
+			return openapi3.NewSchemaRef("./"+attr.SubType+"#/components/schemas/"+attr.SubType, nil), nil
+		}
 		return openapi3.NewSchemaRef("#/components/schemas/"+attr.SubType, nil), nil
 
 	case spec.AttributeTypeRefList:

--- a/cmd/internal/genopenapi3/gen_relations.go
+++ b/cmd/internal/genopenapi3/gen_relations.go
@@ -86,7 +86,11 @@ func (c *converter) extractOperationGetAll(parentRestName string, relation *spec
 	model := relation.Specification().Model()
 
 	respBodySchema := openapi3.NewArraySchema()
-	respBodySchema.Items = openapi3.NewSchemaRef("#/components/schemas/"+model.RestName, nil)
+	if !c.splitOutput || parentRestName == "" {
+		respBodySchema.Items = openapi3.NewSchemaRef("#/components/schemas/"+model.RestName, nil)
+	} else {
+		respBodySchema.Items = openapi3.NewSchemaRef("./"+model.RestName+"#/components/schemas/"+model.RestName, nil)
+	}
 
 	op := &openapi3.Operation{
 		OperationID: "get-all-" + model.ResourceName,
@@ -123,7 +127,13 @@ func (c *converter) extractOperationPost(parentRestName string, relation *spec.R
 
 	model := relation.Specification().Model()
 
-	schemaRef := openapi3.NewSchemaRef("#/components/schemas/"+relation.RestName, nil)
+	var schemaRef *openapi3.SchemaRef
+
+	if !c.splitOutput || parentRestName == "" {
+		schemaRef = openapi3.NewSchemaRef("#/components/schemas/"+relation.RestName, nil)
+	} else {
+		schemaRef = openapi3.NewSchemaRef("./"+relation.RestName+"#/components/schemas/"+relation.RestName, nil)
+	}
 
 	op := &openapi3.Operation{
 		OperationID: "create-a-new-" + relation.RestName,


### PR DESCRIPTION
This PR adds a new flag `--split-output` which breaks down the output openapi3 doc into multiple file... Each file represents a gaia model plus root relations related to that gaia model. Therefore, there will be no root/toplevel document when output is split. Existing test cases weren't changed; the shown changeset in most test files are due to refactoring of the testrunner.