### PR TITLE
fixed: IsZero when using a nil pointer prop

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -129,11 +129,13 @@ func IsZero(o interface{}) bool {
 		return true
 	}
 
-	v := reflect.Indirect(reflect.ValueOf(o))
+	v := reflect.ValueOf(o)
 
-	if v.Type() == reflectedTimeType {
-		return time.Time{}.Equal(v.Interface().(time.Time))
+	if v.IsZero() {
+		return true
 	}
+
+	v = reflect.Indirect(v)
 
 	switch v.Kind() {
 	case reflect.Slice, reflect.Map:

--- a/utils_test.go
+++ b/utils_test.go
@@ -686,6 +686,11 @@ func TestIsZero(t *testing.T) {
 			args{nil},
 			true,
 		},
+		{
+			"nil pointer",
+			args{(*struct{})(nil)},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Previously, IsZero() was panicking when the given object
was a nil pointer. This patch makes IsZero() leverage reflect's
value.IsZero() to simplify the code.