### PR TITLE
Bugfix: completely ignore private models if public flag is passed

### DIFF
--- a/cmd/internal/genopenapi3/converter_model_nonroot_test.go
+++ b/cmd/internal/genopenapi3/converter_model_nonroot_test.go
@@ -139,16 +139,6 @@ func TestConverter_Do__modelsAndAttributes_nonRoot(t *testing.T) {
 				"toplevel": `
 					{
 						"openapi": "3.0.3",
-						"tags": [
-							{
-								"name": "N/A",
-								"description": "This tag is for group 'N/A'"
-							},
-							{
-								"name": "None",
-								"description": "This tag is for package 'None'"
-							}
-						],
 						"info": {
 							"contact": {
 								"email": "dev@aporeto.com",

--- a/cmd/internal/genopenapi3/gen_converter.go
+++ b/cmd/internal/genopenapi3/gen_converter.go
@@ -137,6 +137,9 @@ func (c *converter) cacheTags(model *spec.Model) {
 	if model.IsRoot {
 		return
 	}
+	if c.skipPrivateModels && model.Private {
+		return
+	}
 
 	tags := openapi3.Tags{
 		{

--- a/cmd/internal/genopenapi3/gen_relations.go
+++ b/cmd/internal/genopenapi3/gen_relations.go
@@ -15,6 +15,12 @@ func (c *converter) convertRelationsForRootSpec(relations []*spec.Relation) map[
 
 	for _, relation := range relations {
 
+		model := relation.Specification().Model()
+
+		if c.skipPrivateModels && model.Private {
+			continue
+		}
+
 		if relation.Get == nil && relation.Create == nil {
 			continue
 		}
@@ -24,7 +30,6 @@ func (c *converter) convertRelationsForRootSpec(relations []*spec.Relation) map[
 			Post: c.extractOperationPost("", relation),
 		}
 
-		model := relation.Specification().Model()
 		uri := "/" + model.ResourceName
 		paths[uri] = pathItem
 	}


### PR DESCRIPTION
This PR ensures that not only we avoid converting schemas for private models, but also that we ignore converting tags and root relations that belong to private models ONLY and only if --public flag is passed