### PR TITLE
Fixed: Add NoLower to keep with old behavior

### DIFF
--- a/cmd/elegen/utils.go
+++ b/cmd/elegen/utils.go
@@ -103,7 +103,7 @@ func attributeTypeConverter(typ spec.AttributeType, subtype string) (string, str
 
 func attributeNameConverter(attrName string) string {
 
-	return cases.Title(language.Und).String(attrName)
+	return cases.Title(language.Und, cases.NoLower).String(attrName)
 }
 
 func attrToType(set spec.SpecificationSet, shadow bool, attr *spec.Attribute) string {

--- a/cmd/elegen/writers.go
+++ b/cmd/elegen/writers.go
@@ -29,7 +29,7 @@ import (
 var functions = template.FuncMap{
 	"upper":                           strings.ToUpper,
 	"lower":                           strings.ToLower,
-	"capitalize":                      cases.Title(language.Und).String,
+	"capitalize":                      cases.Title(language.Und, cases.NoLower).String,
 	"join":                            strings.Join,
 	"hasPrefix":                       strings.HasPrefix,
 	"attrBSONFieldName":               attrBSONFieldName,


### PR DESCRIPTION
#### Description
While switching to cases library, we need to make sure to apply `cases.NoLower` to keep the same behavior as before.