### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/cmd/internal/genopenapi3/converter_errors_test.go
+++ b/cmd/internal/genopenapi3/converter_errors_test.go
@@ -13,17 +13,7 @@ import (
 func TestConverter_Do__error_bad_externalType_mapping(t *testing.T) {
 	t.Parallel()
 
-	specDir, err := os.MkdirTemp("", t.Name()+"_*")
-	if err != nil {
-		t.Fatalf("error creating temporary directory for test function: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(specDir); err != nil {
-			// no need to fail the test; it is just a temporary dir that
-			// the OS will eventually destroy, but let's log the error
-			t.Logf("error removing temporary test directory: %v", err)
-		}
-	})
+	specDir := t.TempDir()
 
 	badTypeMapping := replaceTrailingTabsWithDoubleSpaceForYAML(`
 		'[]byte':
@@ -72,17 +62,7 @@ func TestConverter_Do__error_bad_externalType_mapping(t *testing.T) {
 
 func TestConverter_Do__error_writer(t *testing.T) {
 
-	specDir, err := os.MkdirTemp("", t.Name()+"_*")
-	if err != nil {
-		t.Fatalf("error creating temporary directory for test function: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(specDir); err != nil {
-			// no need to fail the test; it is just a temporary dir that
-			// the OS will eventually destroy, but let's log the error
-			t.Logf("error removing temporary test directory: %v", err)
-		}
-	})
+	specDir := t.TempDir()
 
 	rawSpec := replaceTrailingTabsWithDoubleSpaceForYAML(`
 		model:

--- a/cmd/internal/genopenapi3/converter_helpers_test.go
+++ b/cmd/internal/genopenapi3/converter_helpers_test.go
@@ -30,17 +30,7 @@ type testCaseRunner struct {
 func runAllTestCases(t *testing.T, cases map[string]testCase) {
 	t.Helper()
 
-	rootTmpDir, err := os.MkdirTemp("", t.Name()+"_*")
-	if err != nil {
-		t.Fatalf("error creating temporary directory for test function: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(rootTmpDir); err != nil {
-			// no need to fail the test; it is just a temporary dir that
-			// the OS will eventually destroy, but let's log the error
-			t.Logf("error removing temporary test directory: %v", err)
-		}
-	})
+	rootTmpDir := t.TempDir()
 
 	tcRunner := &testCaseRunner{
 		t:          t,


### PR DESCRIPTION
This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(e)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```