### PR TITLE
Fixed: string representation for "not in" filter comparator should show array

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ lint:
 		--disable-all \
 		--skip-files data_test.go \
 		--exclude-use-default=false \
+		--exclude=dot-imports \
 		--exclude=package-comments \
 		--exclude=unused-parameter \
+		--exclude=superfluous-else \
 		--enable=errcheck \
 		--enable=goimports \
 		--enable=ineffassign \

--- a/filters.go
+++ b/filters.go
@@ -409,7 +409,10 @@ func translateOperator(operator FilterOperator) string {
 func translateValue(comparator FilterComparator, value any) string {
 
 	v := reflect.ValueOf(value)
-	if comparator != ContainComparator && comparator != InComparator && comparator != MatchComparator {
+	if comparator != ContainComparator &&
+		comparator != InComparator &&
+		comparator != NotInComparator &&
+		comparator != MatchComparator {
 		if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
 			v = reflect.ValueOf(v.Index(0).Interface())
 		}

--- a/filters_test.go
+++ b/filters_test.go
@@ -210,6 +210,62 @@ func TestFilter_NewComposer(t *testing.T) {
 				})
 			})
 
+			Convey("When I add a new NotIn statement", func() {
+
+				f.WithKey("notin").NotIn("a", "b", "c")
+
+				Convey("Then the filter should be correctly populated", func() {
+					So(f.keys, ShouldResemble, FilterKeys{
+						"hello",
+						"notin",
+					})
+					So(f.Values(), ShouldResemble, FilterValues{
+						FilterValue{1},
+						FilterValue{"a", "b", "c"},
+					})
+					So(f.Operators(), ShouldResemble, FilterOperators{
+						AndOperator,
+						AndOperator,
+					})
+					So(f.Comparators(), ShouldResemble, FilterComparators{
+						EqualComparator,
+						NotInComparator,
+					})
+
+					Convey("When I add a new NotContains statement", func() {
+
+						f.WithKey("notctn").NotContains(false)
+
+						Convey("Then the filter should be correctly populated", func() {
+							So(f.Keys(), ShouldResemble, FilterKeys{
+								"hello",
+								"notin",
+								"notctn",
+							})
+							So(f.Values(), ShouldResemble, FilterValues{
+								FilterValue{1},
+								FilterValue{"a", "b", "c"},
+								FilterValue{false},
+							})
+							So(f.Operators(), ShouldResemble, FilterOperators{
+								AndOperator,
+								AndOperator,
+								AndOperator,
+							})
+							So(f.Comparators(), ShouldResemble, FilterComparators{
+								EqualComparator,
+								NotInComparator,
+								NotContainComparator,
+							})
+
+							Convey("Then the string representation should be correct", func() {
+								So(f.String(), ShouldEqual, `hello == 1 and notin not in ["a", "b", "c"] and notctn not contains false`)
+							})
+						})
+					})
+				})
+			})
+
 			Convey("When I add a new difference comparator", func() {
 				f.WithKey("x").NotEquals(true)
 
@@ -442,7 +498,7 @@ func TestFilter_SubFilters(t *testing.T) {
 							Done(),
 						NewFilterComposer().
 							WithKey("size").In(true, false).
-							WithKey("size").NotIn(1).
+							WithKey("size").NotIn(1, 2).
 							Done(),
 					).
 					Done(),
@@ -450,7 +506,7 @@ func TestFilter_SubFilters(t *testing.T) {
 			Done()
 
 		Convey("When I call string it should be correct ", func() {
-			So(f.String(), ShouldEqual, `namespace == "coucou" and number == 32.900000 and ((name == "toto" and value == 1) and (color contains ["red", "green", "blue", 43] and something not contains "stuff" or ((size matches [".*"]) or (size == "medium" and fat == false) or (size in [true, false] and size not in 1))))`)
+			So(f.String(), ShouldEqual, `namespace == "coucou" and number == 32.900000 and ((name == "toto" and value == 1) and (color contains ["red", "green", "blue", 43] and something not contains "stuff" or ((size matches [".*"]) or (size == "medium" and fat == false) or (size in [true, false] and size not in [1, 2]))))`)
 		})
 	})
 }


### PR DESCRIPTION
This PR fixes the following bug:
Given the following filter:
```
f := elemental.NewFilter().WithKey("name").NotIn("abc001", "abc002").Done()
```
The `f.String()` representation only shows the first element:
```
(name not in "abc001")
```
The correct, expected representation is:
```
(name not in ["abc001", "abc002"])
```
Which is analogous to the behaviour of the `In` comparator:
```
f := elemental.NewFilter().WithKey("name").In("abc001", "abc002").Done()
``` 
which returns the following `f.String()` representation:
```
(name in ["abc001", "abc002"])
```